### PR TITLE
Add config flag to permit apps with no auth gate

### DIFF
--- a/src/lib/app-service.js
+++ b/src/lib/app-service.js
@@ -140,8 +140,10 @@ function setupClient (client, {config, server, datacache, interface: _interface,
 
 	clientRoute.use(ANONYMOUS_ROUTES, (r, q, n) => void session.anonymousMiddleware(basepath, r, q, n));
 
-	//Session manager...
-	clientRoute.use(AUTHENTICATED_ROUTES, (r, q, n) => void session.middleware(basepath, r, q, n));
+	if (config.public !== true) {
+		//Session manager...
+		clientRoute.use(AUTHENTICATED_ROUTES, (r, q, n) => void session.middleware(basepath, r, q, n));
+	}
 
 	//HTML Renderer...
 	clientRoute.get('*', getPageRenderer(client, config, datacache, render, renderContent));


### PR DESCRIPTION
Allow the web service to host applications that do not have an auth gate.